### PR TITLE
Handled initWithCoder so the lib can be used with storyboards

### DIFF
--- a/GTScrollNavigationBar/GTScrollNavigationBar.m
+++ b/GTScrollNavigationBar/GTScrollNavigationBar.m
@@ -24,24 +24,37 @@
             panGesture = _panGesture,
             lastContentOffsetY = _lastContentOffsetY;
 
+- (id)initWithCoder:(NSCoder *)aDecoder {
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        [self setup];
+    }
+    return self;
+}
+
 - (id)initWithFrame:(CGRect)frame
 {
     self = [super initWithFrame:frame];
     if (self) {
-        self.panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self
-                                                                  action:@selector(handlePan:)];
-        self.panGesture.delegate = self;
-        
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(applicationDidBecomeActive)
-                                                     name:UIApplicationDidBecomeActiveNotification
-                                                   object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(statusBarOrientationDidChange)
-                                                     name:UIApplicationDidChangeStatusBarOrientationNotification
-                                                   object:nil];
+        [self setup];
     }
     return self;
+}
+
+- (void)setup
+{
+    self.panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self
+                                                              action:@selector(handlePan:)];
+    self.panGesture.delegate = self;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(applicationDidBecomeActive)
+                                                 name:UIApplicationDidBecomeActiveNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(statusBarOrientationDidChange)
+                                                 name:UIApplicationDidChangeStatusBarOrientationNotification
+                                               object:nil];    
 }
 
 - (void)dealloc


### PR DESCRIPTION
Storyboards use initWithCoder: instead of initWithFrame: ... your setup stuff get ignored unless you initialize properties in both.
