### PR TITLE
Fixed when the Content size is smaller than the frame size

### DIFF
--- a/GTScrollNavigationBar/GTScrollNavigationBar.m
+++ b/GTScrollNavigationBar/GTScrollNavigationBar.m
@@ -117,6 +117,10 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         return;
     }
     
+    if ( self.scrollView.frame.size.height + (self.bounds.size.height * 2) >= self.scrollView.contentSize.height) {
+        return;
+    }
+    
     CGFloat contentOffsetY = self.scrollView.contentOffset.y;
     
     if (contentOffsetY < -self.scrollView.contentInset.top) {

--- a/GTScrollNavigationBarExample/GTScrollNavigationBarExample/DemoTableViewController.m
+++ b/GTScrollNavigationBarExample/GTScrollNavigationBarExample/DemoTableViewController.m
@@ -66,7 +66,7 @@
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {
-    return 100;
+    return 4;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
When the ContentSize of a UIScrollView is smaller than the size of the
frame the animation looks so weird because the UINavigationBar starts
the animation when it should not be animated.
