### PR TITLE
Workaround for iOS 8 rotation

### DIFF
--- a/GTScrollNavigationBar/GTScrollNavigationBar.m
+++ b/GTScrollNavigationBar/GTScrollNavigationBar.m
@@ -175,6 +175,9 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 #pragma mark - helper methods
 - (CGFloat)statusBarTopOffset
 {
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0f){
+        return CGRectGetHeight([UIApplication sharedApplication].statusBarFrame)+[UIApplication sharedApplication].statusBarFrame.origin.y;
+    }
     switch ([UIApplication sharedApplication].statusBarOrientation) {
         case UIInterfaceOrientationPortrait:
         case UIInterfaceOrientationPortraitUpsideDown:


### PR DESCRIPTION
Always return "status bar height + status bar Y" in a helper "statusBarTopOffset".