### PR TITLE
Bring Swift interactions to GTScrollNavigationBar

### DIFF
--- a/GTScrollNavigationBar.podspec
+++ b/GTScrollNavigationBar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "GTScrollNavigationBar"
-  s.version      = "0.3"
+  s.version      = "0.4"
   s.summary      = "A scrollable UINavigationBar that follows a UIScrollView"
   s.homepage     = "https://github.com/luugiathuy/GTScrollNavigationBar"
   s.license      = 'BSD'

--- a/GTScrollNavigationBar/GTScrollNavigationBar.h
+++ b/GTScrollNavigationBar/GTScrollNavigationBar.h
@@ -8,11 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
-typedef enum {
-    GTScrollNavigationBarNone,
-    GTScrollNavigationBarScrollingDown,
-    GTScrollNavigationBarScrollingUp
-} GTScrollNavigationBarState;
+typedef NS_ENUM(NSInteger, GTScrollNavigationBarState) {
+    GTScrollNavigationBarStateNone,
+    GTScrollNavigationBarStateScrollingDown,
+    GTScrollNavigationBarStateScrollingUp
+};
 
 @interface GTScrollNavigationBar : UINavigationBar
 

--- a/GTScrollNavigationBar/GTScrollNavigationBar.m
+++ b/GTScrollNavigationBar/GTScrollNavigationBar.m
@@ -83,7 +83,7 @@
 #pragma mark - Public methods
 - (void)resetToDefaultPositionWithAnimation:(BOOL)animated
 {
-    self.scrollState = GTScrollNavigationBarNone;
+    self.scrollState = GTScrollNavigationBarStateNone;
     CGRect frame = self.frame;
     frame.origin.y = [self statusBarTopOffset];
     [self setFrame:frame alpha:1.0f animated:animated];
@@ -124,16 +124,16 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     
     // Reset scrollState when the gesture began
     if (gesture.state == UIGestureRecognizerStateBegan) {
-        self.scrollState = GTScrollNavigationBarNone;
+        self.scrollState = GTScrollNavigationBarStateNone;
         self.lastContentOffsetY = contentOffsetY;
         return;
     }
     
     CGFloat deltaY = contentOffsetY - self.lastContentOffsetY;
     if (deltaY < 0.0f) {
-        self.scrollState = GTScrollNavigationBarScrollingDown;
+        self.scrollState = GTScrollNavigationBarStateScrollingDown;
     } else if (deltaY > 0.0f) {
-        self.scrollState = GTScrollNavigationBarScrollingUp;
+        self.scrollState = GTScrollNavigationBarStateScrollingUp;
     }
     
     CGRect frame = self.frame;
@@ -149,19 +149,19 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         return;
     }
     
-    bool isScrolling = (self.scrollState == GTScrollNavigationBarScrollingUp ||
-                        self.scrollState == GTScrollNavigationBarScrollingDown);
+    bool isScrolling = (self.scrollState == GTScrollNavigationBarStateScrollingUp ||
+                        self.scrollState == GTScrollNavigationBarStateScrollingDown);
     
     bool gestureIsActive = (gesture.state != UIGestureRecognizerStateEnded &&
                             gesture.state != UIGestureRecognizerStateCancelled);
     
     if (isScrolling && !gestureIsActive) {
         // Animate navigation bar to end position
-        if (self.scrollState == GTScrollNavigationBarScrollingDown) {
+        if (self.scrollState == GTScrollNavigationBarStateScrollingDown) {
             frame.origin.y = maxY;
             alpha = 1.0f;
         }
-        else if (self.scrollState == GTScrollNavigationBarScrollingUp) {
+        else if (self.scrollState == GTScrollNavigationBarStateScrollingUp) {
             frame.origin.y = minY;
             alpha = kNearZero;
         }


### PR DESCRIPTION
By updating enum state to the standard swift way.

I upgraded podspec to `0.4` also since this could break some local implementations (due to renaming the state enum). If so developers could block the update by putting `pod 'GTScrollNavigationBar', '~> 0.3.0'` in their podfile.

Cheers