### PR TITLE
During the frame animation make sure the content offset is also animated

### DIFF
--- a/GTScrollNavigationBar/GTScrollNavigationBar.m
+++ b/GTScrollNavigationBar/GTScrollNavigationBar.m
@@ -221,6 +221,9 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         parentViewFrame.origin.y += offsetY;
         parentViewFrame.size.height -= offsetY;
         self.scrollView.superview.frame = parentViewFrame;
+        if (animated) {
+            self.scrollView.contentOffset = CGPointMake(self.scrollView.contentOffset.x, self.scrollView.contentOffset.y - offsetY);
+        }
     }
     
     if (animated) {


### PR DESCRIPTION
This imposes a significant problem if the scrollview has floating items on top that have to be repositioned everytime the content is scrolled.